### PR TITLE
feat: Enable Snapdragon 8 Gen 1 support and add Android build instruc…

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -2,19 +2,68 @@
 # Android
 
 ## Build on Android using Termux
-[Termux](https://github.com/termux/termux-app#installation) is a method to execute `llama.cpp` on an Android device (no root required).
-```
-apt update && apt upgrade -y
-apt install git make cmake
-```
+[Termux](https://github.com/termux/termux-app#installation) is a powerful terminal emulator and Linux environment for Android that allows you to build and run `llama.cpp` directly on your device without needing root access.
 
-It's recommended to move your model inside the `~/` directory for best performance:
-```
-cd storage/downloads
-mv model.gguf ~/
-```
+**1. Install Termux and Required Packages:**
 
-[Get the code](https://github.com/ggerganov/llama.cpp#get-the-code) & [follow the Linux build instructions](https://github.com/ggerganov/llama.cpp#build) to build `llama.cpp`.
+   First, install Termux from F-Droid or GitHub. After installation, open Termux and run the following commands to update packages and install necessary build tools:
+   ```bash
+   pkg update && pkg upgrade -y
+   pkg install git cmake clang make
+   ```
+
+**2. Get the Code:**
+
+   Clone the `llama.cpp` repository:
+   ```bash
+   git clone https://github.com/ggerganov/llama.cpp.git
+   cd llama.cpp
+   ```
+
+**3. Build `llama.cpp`:**
+
+   Create a build directory and compile the project using CMake:
+   ```bash
+   mkdir build
+   cd build
+   cmake ..
+   make -j$(nproc)
+   ```
+   This will build the necessary binaries (like `main`, `server`, etc.) in the `build/bin` directory. The build process should automatically detect and enable optimizations for your device's CPU, including Snapdragon 8 Gen 1 and similar processors with DOTPROD support.
+
+**4. Download a Model:**
+
+   You'll need a GGUF-formatted model file. You can download one from Hugging Face or other sources. For example, to download a small test model:
+   ```bash
+   # From the llama.cpp/build directory
+   cd ../
+   # Example: Download a small Phi-3 model (replace with your desired model)
+   curl -L -o models/phi-3-mini-4k-instruct.Q4_K_M.gguf https://huggingface.co/microsoft/Phi-3-mini-4k-instruct-gguf/resolve/main/Phi-3-mini-4k-instruct.Q4_K_M.gguf?download=true
+   # Ensure the models directory exists
+   mkdir -p models
+   # If you downloaded it elsewhere, move it to the models directory or your preferred location.
+   ```
+   It's often recommended to store models in Termux's home directory (`~/`) or a subdirectory for easy access.
+
+**5. Run `llama.cpp`:**
+
+   Navigate to the directory containing the executables and run them. For example, to run the `main` example for inference:
+   ```bash
+   cd build/bin
+   ./main -m ../../models/phi-3-mini-4k-instruct.Q4_K_M.gguf -n 256 --color -i -ins
+   ```
+   Replace `phi-3-mini-4k-instruct.Q4_K_M.gguf` with the path to your downloaded model.
+
+   To run the server:
+   ```bash
+   ./server -m ../../models/phi-3-mini-4k-instruct.Q4_K_M.gguf -c 4096
+   ```
+
+**Troubleshooting:**
+
+*   **Storage Access:** If you need to access files on your shared storage (e.g., SD card or Downloads folder), run `termux-setup-storage` in Termux and grant the necessary permissions.
+*   **Performance:** Building directly in Termux provides good performance. Ensure your device has sufficient RAM and storage. Background processes on Android can sometimes interfere; closing unnecessary apps might help.
+*   **CPU Features:** The build process is designed to automatically detect CPU features. If you encounter "Illegal instruction" errors with pre-built binaries or suspect an issue, rebuilding from source within Termux is the best way to ensure compatibility.
 
 ## Building the Project using Android NDK
 Obtain the [Android NDK](https://developer.android.com/ndk) and then build with CMake.

--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -1154,10 +1154,37 @@ if (CMAKE_OSX_ARCHITECTURES      STREQUAL "arm64" OR
 
         set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_PREV})
     else()
+            # Common ARM flags
         check_cxx_compiler_flag(-mfp16-format=ieee COMPILER_SUPPORTS_FP16_FORMAT_I3E)
         if (NOT "${COMPILER_SUPPORTS_FP16_FORMAT_I3E}" STREQUAL "")
             list(APPEND ARCH_FLAGS -mfp16-format=ieee)
         endif()
+
+            # Check for DOTPROD support
+            set(CMAKE_REQUIRED_FLAGS_PREV ${CMAKE_REQUIRED_FLAGS})
+            set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -march=armv8.2-a+dotprod")
+            check_cxx_source_compiles("#include <arm_neon.h>\n#ifndef __ARM_FEATURE_DOTPROD\n#error \"__ARM_FEATURE_DOTPROD not defined\"\n#endif\nint main() { return 0; }" GGML_COMPILER_DEFINES_DOTPROD_FLAG_GCC)
+            set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_PREV})
+
+            if (GGML_COMPILER_DEFINES_DOTPROD_FLAG_GCC)
+                message(STATUS "ARM DOTPROD support detected with -march=armv8.2-a+dotprod")
+                list(APPEND ARCH_FLAGS -march=armv8.2-a+dotprod)
+                # Some compilers might not define __ARM_FEATURE_DOTPROD automatically even with march flag
+                add_compile_definitions(__ARM_FEATURE_DOTPROD)
+            else()
+                # Fallback check if the compiler defines __ARM_FEATURE_DOTPROD without specific march flag (e.g. newer default arch)
+                set(CMAKE_REQUIRED_FLAGS_PREV ${CMAKE_REQUIRED_FLAGS})
+                # No specific march flag, rely on compiler's default for the processor or other flags
+                check_cxx_source_compiles("#include <arm_neon.h>\n#ifndef __ARM_FEATURE_DOTPROD\n#error \"__ARM_FEATURE_DOTPROD not defined\"\n#endif\nint main() { return 0; }" GGML_COMPILER_DEFINES_DOTPROD_NATIVELY_GCC)
+                set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS_PREV})
+                if(GGML_COMPILER_DEFINES_DOTPROD_NATIVELY_GCC)
+                    message(STATUS "ARM DOTPROD support detected (likely native or due to other flags)")
+                    add_compile_definitions(__ARM_FEATURE_DOTPROD)
+                else()
+                    message(STATUS "ARM DOTPROD support not detected or compiler does not define __ARM_FEATURE_DOTPROD. iqk_mul_mat might not be optimized.")
+                endif()
+            endif()
+
         if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "armv6")
             # Raspberry Pi 1, Zero
             list(APPEND ARCH_FLAGS -mfpu=neon-fp-armv8 -mno-unaligned-access)


### PR DESCRIPTION
…tions

- Modified ggml/src/CMakeLists.txt to automatically detect and enable ARM DOTPROD CPU features for non-MSVC compilers (e.g., Clang on Termux). This resolves 'Unsupported CPU' errors on devices like Snapdragon 8 Gen 1 by ensuring IQK_IMPLEMENT is defined.
- Updated docs/android.md with comprehensive instructions for building and running llama.cpp on Android using Termux.



- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ ] Medium
  - [ ] High
